### PR TITLE
Fully Define `getUserFlagSettings` Response

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -568,7 +568,7 @@ UserFlagSettings:
             self:
               href: /api/v2/users/lacuna/production/Abbie_Braun/flags/alternate.page
               type: application/json
-          _value: 'false,'
+          _value: false,
           setting: null
 Statements:
   type: array

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -553,6 +553,8 @@ UserFlagSettings:
       $ref: '#/definitions/Links'
     items:
       type: object
+      additionalProperties:
+        $ref: '#/definitions/UserFlagSetting'
       example:
         sort.order:
           _links:
@@ -566,7 +568,7 @@ UserFlagSettings:
             self:
               href: /api/v2/users/lacuna/production/Abbie_Braun/flags/alternate.page
               type: application/json
-          _value: false,
+          _value: 'false,'
           setting: null
 Statements:
   type: array


### PR DESCRIPTION
When querying `getUserFlagSettings` using a generated SDK from the OpenApi spec, the object returned did not correctly expose `UserFlagSettings.Items` as a dictionary of `UserFlagSetting`s.  

In particular, the C# swagger-codegen interpreted `UserFlagSettings.Items` as simply an `object`.    This PR contains a suggested correction that makes the `items` object a well-defined a dictionary of `UserFlagSetting`s.

I've included what the combined YAML file is as a text attachment below.  Using this file, I've been able to re-generate the C# SDK using [swagger-codegen](https://github.com/swagger-api/swagger-codegen).  The generated output matches the manual patch I made earlier today after we used codegen, and is also able to deserialize properly.

Great API y'all, keep up the good work! 😄 

[ld_swagger.yaml (uploaded as a txt)](https://github.com/launchdarkly/ld-openapi/files/1922576/ld_swagger.txt)

[Swagger Specification](https://swagger.io/docs/specification/data-models/dictionaries/) about the change made.