### PR TITLE
Add missing description parameter to FeatureFlagPostRequest

### DIFF
--- a/spec/parameters.yaml
+++ b/spec/parameters.yaml
@@ -51,6 +51,10 @@ FeatureFlagPostRequest:
         type: string
         description: A unique key that will be used to reference the flag in your code.
         example: "new-test-flag"
+      description:
+        type: string
+        description: A description of the feature flag.
+        example: This flag controls whether test feature is turned on or not.
       variations:
         type: array
         items:


### PR DESCRIPTION
It is possible to create flags with a description via the API.

In fact, it's even part of the example at https://apidocs.launchdarkly.com/docs/create-feature-flag