### PR TITLE
Fix openapi definition for custom property map on flag.

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -102,7 +102,11 @@ FeatureFlag:
       type: integer
       example: 23
     customProperties:
-      $ref: '#/definitions/CustomProperties'
+      type: object
+      description: A mapping of keys to CustomProperty entries.
+      additionalProperties:
+        $ref: '#/definitions/CustomProperty'
+      example: { "bugs": { "name": "Issue tracker ids", "value": ["123", "456"] }, "deprecated": { "name": "Deprecated Date", "value": [] } }
     _links:
       $ref: '#/definitions/Links'
     _maintainer:
@@ -731,12 +735,6 @@ PatchOperation:
     - op
     - path
     - value
-CustomProperties:
-  type: object
-  description: A mapping of keys to CustomProperty entries.
-  items:
-    $ref: '#/definitions/CustomProperty'
-  example: { "bugs": { "name": "Issue tracker ids", "value": ["123", "456"] }, "deprecated": { "name": "Deprecated Date", "value": [] } }
 CustomProperty:
   type: object
   description: A name and value describing a custom property.


### PR DESCRIPTION
Defining `CustomProperties` in definitions.yml also caused the go code
generator to skip the field, so we inline the map definition to avoid that
problem.

Fixes issue described in https://github.com/launchdarkly/ld-openapi/pull/13