### PR TITLE
Add flag status across environments to def and paths

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -808,4 +808,9 @@ CustomProperty:
         example: ["Value 1", "Value 2"]
   required:
     - name
-
+BetaError:
+  type: object
+  properties:
+    'message':
+      type: string
+      example: "This is a beta API, you must pass beta in the LD-API-Version header to use it."

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -121,6 +121,15 @@ FeatureFlag:
       type: object
       additionalProperties:
         $ref: '#/definitions/FeatureFlagConfig'
+    archivedDate:
+      type: number
+      format: int64
+      description: A unix epoch time in milliseconds specifying the archived time of this flag.
+      example: 1443652232590
+    archived:
+      type: boolean
+      description: Whether or not this flag is archived.
+      example: false
 FeatureFlags:
   type: object
   properties:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -318,6 +318,37 @@ FeatureFlagStatuses:
       type: array
       items:
         $ref: '#/definitions/FeatureFlagStatus'
+FeatureFlagStatusForQueriedEnvironment:
+  type: object
+  properties:
+    name:
+      type: string
+      description: |
+        | Name     | Description |
+        | --------:| ----------- |
+        | new      | the feature flag was created within the last 7 days, and has not been requested yet |
+        | active   | the feature flag was requested by your servers or clients within the last 7 days |
+        | inactive | the feature flag was created more than 7 days ago, and hasn't been requested by your servers or clients within the past 7 days |
+        | launched | one variation of the feature flag has been rolled out to all your users for at least 7 days |
+      enum:
+        - new
+        - active
+        - inactive
+        - launched
+    lastRequested:
+      type: string
+      example: "2016-08-16T21:10:11.886Z"
+    default:
+      type: object
+FeatureFlagStatusAcrossEnvironments:
+  type: object
+  properties:
+    _links:
+      $ref: '#/definitions/Links'
+    environments:
+      type: object
+      environmentKey:
+        $ref: '#/definitions/FeatureFlagStatusForQueriedEnvironment'
 UserSegment:
   type: object
   required:

--- a/spec/paths.yaml
+++ b/spec/paths.yaml
@@ -16,6 +16,8 @@
   $ref: ./paths/flags.yaml#/FlagStatuses
 /flag-statuses/{projectKey}/{environmentKey}/{featureFlagKey}:
   $ref: ./paths/flags.yaml#/FlagStatus
+/flag-status/{projectKey}/{featureFlagKey}:
+  $ref: ./paths/flags.yaml#/FlagStatusAcrossEnvironments
 /segments/{projectKey}/{environmentKey}:
   $ref: ./paths/segments.yaml#/UserSegments
 /segments/{projectKey}/{environmentKey}/{userSegmentKey}:

--- a/spec/paths/flags.yaml
+++ b/spec/paths/flags.yaml
@@ -161,5 +161,7 @@ FlagStatusAcrossEnvironments:
           $ref: '#/definitions/FeatureFlagStatusAcrossEnvironments'
       '401':
         $ref: '#/responses/Standard401'
+      '403':
+        $ref: '#/responses/BetaApi403'
     tags:
       - Feature flags

--- a/spec/paths/flags.yaml
+++ b/spec/paths/flags.yaml
@@ -147,4 +147,19 @@ FlagStatus:
         $ref: '#/responses/Standard401'
     tags:
       - Feature flags
-      
+FlagStatusAcrossEnvironments:
+  get:
+    summary: Get the status for a particular feature flag across environments
+    operationId: getFeatureFlagStatusAcrossEnvironments
+    parameters:
+      - $ref: '#/parameters/ProjectKey'
+      - $ref: '#/parameters/FeatureFlagKey'
+    responses:
+      '200':
+        description: Status of the requested feature flag across environments
+        schema:
+          $ref: '#/definitions/FeatureFlagStatusAcrossEnvironments'
+      '401':
+        $ref: '#/responses/Standard401'
+    tags:
+      - Feature flags

--- a/spec/responses.yaml
+++ b/spec/responses.yaml
@@ -41,4 +41,4 @@
   BetaApi403:
     description: This is a beta API, you must pass beta in the LD-API-Version header to use it.
     schema:
-      $ref: '#/definitions/UsageError'
+      $ref: '#/definitions/BetaError'

--- a/spec/responses.yaml
+++ b/spec/responses.yaml
@@ -38,3 +38,7 @@
     description: Environment response.
     schema:
       $ref: '#/definitions/Environment'
+  BetaApi403:
+    description: This is a beta API, you must pass beta in the LD-API-Version header to use it.
+    schema:
+      $ref: '#/definitions/UsageError'


### PR DESCRIPTION
Added Archived and ArchivedDate to flag definition for IH support
here's the new endpoint that open-api will include:
https://apidocs.launchdarkly.com/reference#get-flag-status-across-environments