### PR TITLE
Release 2.0.23

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -253,6 +253,8 @@ Fallthrough:
 Rollout:
   type: object
   properties:
+    bucketBy:
+      type: string
     variations:
       type: array
       items:

--- a/spec/info.yaml
+++ b/spec/info.yaml
@@ -8,4 +8,4 @@ contact:
 license:
   name: Apache 2.0
   url: http://www.apache.org/licenses/LICENSE-2.0.html
-version: 2.0.22
+version: 2.0.23

--- a/spec/parameters.yaml
+++ b/spec/parameters.yaml
@@ -228,13 +228,13 @@ SummaryQuery:
   in: query
   required: false
   description: By default in api version >= 1, flags will _not_ include their list of prerequisites, targets or rules.  Set summary=0 to include these fields for each flag returned.
-  type: string
+  type: boolean
 ArchivedQuery:
   name: archived
   in: query
   required: false
   description: When set to 1, archived flags will be included in the list of flags returned.  By default, archived flags are not included in the list of flags.
-  type: string
+  type: boolean
 FeatureFlagKey:
   name: featureFlagKey
   in: path


### PR DESCRIPTION
## Fixed
* Make summary and archived query params booleans

## Added
* Add bucketBy property to flag rollout
