### PR TITLE
prepare 3.3.2 release

### DIFF
--- a/.ldrelease/prepare.sh
+++ b/.ldrelease/prepare.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Remove broken libc6-dev (ch77386)
+sudo apt-get purge libc6-dev
+sudo apt-get autoremove
+sudo apt-get clean
+sudo apt-get install -f
+
 # Install Python tools and AWS CLI
 sudo apt update
 sudo apt install awscli python3-pip python3-setuptools

--- a/scripts/release/python.sh
+++ b/scripts/release/python.sh
@@ -5,6 +5,5 @@ path=$1
 name=$2
 
 cd ${path}/
-python setup.py bdist_wheel --universal
+python3 setup.py bdist_wheel --universal
 twine upload dist/*
-

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -433,8 +433,10 @@ UserTargetingExpirationForFlag:
   type: object
   properties:
     expirationDate:
-      type: integer
-      description: Date scheduled for expiration
+      type: number
+      format: int64
+      description: Unix epoch time in milliseconds specifying the expiration date
+      example: 1735689600000
     variationId:
       type: string
       description: the ID of the variation that the user is targeted on a flag
@@ -453,8 +455,10 @@ UserTargetingExpirationForSegment:
   type: object
   properties:
     expirationDate:
-      type: integer
-      description: Date scheduled for expiration
+      type: number
+      format: int64
+      description: Unix epoch time in milliseconds specifying the expiration date
+      example: 1735689600000
     targetType:
       type: string
       description: either the included or excluded variation that the user is targeted on a segment

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -84,7 +84,7 @@ FeatureFlag:
       description: Whether the feature flag is a boolean flag or multivariate.
       example: boolean
     creationDate:
-      type: number
+      type: integer
       format: int64
       description: A unix epoch time in milliseconds specifying the creation time of this flag.
       example: 1443652232590
@@ -139,7 +139,7 @@ FeatureFlag:
       additionalProperties:
         $ref: "#/definitions/FeatureFlagConfig"
     archivedDate:
-      type: number
+      type: integer
       format: int64
       description: A unix epoch time in milliseconds specifying the archived time of this flag.
       example: 1443652232590
@@ -433,7 +433,7 @@ UserTargetingExpirationForFlag:
   type: object
   properties:
     expirationDate:
-      type: number
+      type: integer
       format: int64
       description: Unix epoch time in milliseconds specifying the expiration date
       example: 1735689600000
@@ -455,7 +455,7 @@ UserTargetingExpirationForSegment:
   type: object
   properties:
     expirationDate:
-      type: number
+      type: integer
       format: int64
       description: Unix epoch time in milliseconds specifying the expiration date
       example: 1735689600000
@@ -512,7 +512,7 @@ UserSegment:
       example: ["dev", "ops"]
       description: An array of tags for this user segment.
     creationDate:
-      type: number
+      type: integer
       format: int64
       description: A unix epoch time in milliseconds specifying the creation time of this flag.
       example: 1443652232590
@@ -805,7 +805,6 @@ UserRecord:
   properties:
     lastPing:
       type: string
-      format: int64
       example: "2015-03-03T02:37:22.492Z"
     environmentId:
       type: string
@@ -1163,12 +1162,12 @@ StreamUsageSeries:
   type: object
   properties:
     "0":
-      type: number
+      type: integer
       format: int64
       description: A key corresponding to a time series data point.
       example: 0
     "time":
-      type: number
+      type: integer
       format: int64
       description: A unix epoch time in milliseconds specifying the creation time of this flag.
       example: 1551740400000

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -314,6 +314,9 @@ Variation:
   required:
     - value
   properties:
+    _id:
+      type: string
+      example: "24b32dd3-0ba6-46ee-86af-230eebf3c7cb"
     name:
       type: string
       example: "True"
@@ -441,9 +444,9 @@ UserTargetingExpirationForFlag:
     _id:
       type: string
     _resourceId:
-      $ref: '#/definitions/UserTargetingExpirationResourceIdForFlag'
+      $ref: "#/definitions/UserTargetingExpirationResourceIdForFlag"
     _links:
-      $ref: '#/definitions/Links'
+      $ref: "#/definitions/Links"
     _version:
       type: integer
 UserTargetingExpirationForSegment:
@@ -461,9 +464,9 @@ UserTargetingExpirationForSegment:
     _id:
       type: string
     _resourceId:
-      $ref: '#/definitions/UserTargetingExpirationResourceIdForFlag'
+      $ref: "#/definitions/UserTargetingExpirationResourceIdForFlag"
     _links:
-      $ref: '#/definitions/Links'
+      $ref: "#/definitions/Links"
     _version:
       type: integer
 UserTargetingExpirationResourceIdForFlag:
@@ -1053,7 +1056,7 @@ SemanticPatchOperation:
         properties:
           kind:
             type: string
-            example: 'removeUserTargets'
+            example: "removeUserTargets"
             description: The name of the modification you would like to perform on a resource.
   required:
     - instructions

--- a/spec/parameters.yaml
+++ b/spec/parameters.yaml
@@ -336,7 +336,7 @@ After:
   name: after
   in: query
   required: false
-  description: A timestamp filter, expressed as a Unix epoch time in milliseconds. All entries returned will have occured after this timestamp.
+  description: A timestamp filter, expressed as a Unix epoch time in milliseconds. All entries returned will have occurred after this timestamp.
   format: int64
   type: integer
 PatchRequest:
@@ -371,7 +371,7 @@ Q:
   name: q
   in: query
   required: false
-  description: Text to search for. You can search for the full or partial name of the resource involved or fullpartial email address of the member who made the change.
+  description: Text to search for. You can search for the full or partial name of the resource involved or full or partial email address of the member who made the change.
   type: string
 AuditLimit:
   name: limit

--- a/spec/parameters.yaml
+++ b/spec/parameters.yaml
@@ -249,11 +249,11 @@ LimitQuery:
   description: The number of objects to return. Defaults to -1, which returns everything.
   type: number
 OffsetQuery:
-  name: number
+  name: offset
   in: query
   required: false
   description: Where to start in the list. This is for use with pagination. For example, an offset of 10 would skip the first 10 items and then return the next limit items.
-  type: boolean
+  type: number
 FilterQuery:
   name: filter
   in: query


### PR DESCRIPTION
## [3.3.2] - 2020-06-05
### Fixed:
- Epoch timestamp values are now correctly specified as `type: integer` instead of `type: number`


