### PR TITLE
adding a stub circleci config to avoid a broken build on the gh-pages branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+# stub configuration to prevent CircleCI from building this branch
+version: 2
+jobs:
+  empty-job:
+    docker:
+      - image: ubuntu:18.10
+    steps: []
+
+workflows:
+  version: 2
+  empty-build:
+    jobs:
+      - empty-job:
+          filters:
+            branches: 
+              only: not-gh-pages


### PR DESCRIPTION
I copied [this file](https://github.com/launchdarkly/java-server-sdk/blob/gh-pages/.circleci/config.yml) to avoid broken gh-pages builds like the one from last night's release.