### PR TITLE
Fix the parameters and return type for `Get Evaluations Usage`

### DIFF
--- a/spec/parameters.yaml
+++ b/spec/parameters.yaml
@@ -586,6 +586,12 @@ EventType:
   required: true
   description: The type of event we would like to track.
   type: string
+EvaluationProjectKey:
+  name: projectKey
+  in: path
+  required: true
+  description: The project key that we want metrics from
+  type: string
 #  example: 'published'
 EvaluationEnvId:
   name: envId
@@ -600,6 +606,25 @@ EvaluationFlagKey:
   required: true
   description: The key of the flag we want metrics for.
   type: string
+EvaluationFrom:
+  name: from
+  in: query
+  required: false
+  description: A timestamp filter, expressed as a Unix epoch time in milliseconds. All entries returned will have occurred after this timestamp.
+  format: int64
+  type: integer
+EvaluationTo:
+  name: to
+  in: query
+  required: false
+  description: A timestamp filter, expressed as a Unix epoch time in milliseconds. All entries returned will have occurred before this timestamp.
+  format: int64
+  type: integer
+EvaluationTimeZone:
+  name: tz
+  in: query
+  required: false
+  description: The timezone to use for breaks between days when returning daily data.
 #  example: ''
 TokensPostRequest:
   name: tokenBody

--- a/spec/paths/usage.yaml
+++ b/spec/paths/usage.yaml
@@ -136,13 +136,18 @@ Evaluations:
     summary: "[BETA] Get events usage by event id and the feature flag key."
     operationId: getEvaluations
     parameters:
+      - $ref: '#/parameters/EvaluationProjectKey'
       - $ref: '#/parameters/EvaluationEnvId'
       - $ref: '#/parameters/EvaluationFlagKey'
+      - $ref: '#/parameters/EvaluationFrom'
+      - $ref: '#/parameters/EvaluationTo'
+      - $ref: '#/parameters/EvaluationTimeZone'
+
     responses:
       '200':
         description: Returns timeseries data and all sdk versions.
         schema:
-          $ref: '#/definitions/StreamSDKVersion'
+          $ref: '#/definitions/Stream'
       '403':
         $ref: '#/responses/BetaApi403'
       '404':


### PR DESCRIPTION
The openAPI spec for the `usage/evaluations` or `Get Evaluations Usage` endpoint is wrong. The endpoint should also take in the project key in the path, and it should take in `to` `from` and `tz` as arguments in the query. Also the return type is `Stream` not `StreamSDKVersion`. This is based on [your apidocs](https://apidocs.launchdarkly.com/reference#get-evaluations-usage) and confirmed by inspecting the requests made on the insights tab of a flag.

I haven't installed all of the tooling required to compile this and check the validity of these changes. I would prefer not to have to, but can if need be. Thanks for your help