### PR TITLE
Update CODEOWNERS: rename team-fm-next to team-fm-foundations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @launchdarkly/team-fm-next
+* @launchdarkly/team-fm-foundations


### PR DESCRIPTION
## Summary

Renames the CODEOWNERS team reference from `@launchdarkly/team-fm-next` to `@launchdarkly/team-fm-foundations` to reflect the team's new name. This is part of a bulk update across multiple repos in the org.

## Review & Testing Checklist for Human

- [ ] Verify that `@launchdarkly/team-fm-foundations` exists as a valid GitHub team in the org (if it doesn't, CODEOWNERS enforcement will break)

### Notes

This same change is being applied across all repos that reference `@launchdarkly/team-fm-next` in their CODEOWNERS files.

Link to Devin session: https://app.devin.ai/sessions/8abe80d07e414755864c1b9c67215686
Requested by: @kparkinson-ld